### PR TITLE
Define reserved names

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,36 @@ implementation.
 The specification can be retrieved from the Zigbee Alliance
 [Developer portal](https://zigbeealliance.org/developer_resources/?file_type%5B%5D=specification)
 
+## Reserved names
+
+These names are reserved for functions related to attributes and commands, 
+they should not be used as a attribute/argument names:
+
+* AddValues
+* Arguments
+* ArrayTypeID
+* ArrayValues
+* Cluster
+* Description
+* Direction
+* Handle
+* ID
+* MarshalZcl
+* MnfCode
+* Name
+* Readable
+* Reportable
+* Required
+* SceneIndex
+* SetValue
+* SetValues
+* String
+* TypeID
+* UnmarshalZcl
+* Value
+* Values
+* Writable
+
 ## Attribution
 
 A number of definitions were originally sourced from Dresden Elektronik's

--- a/clusters/lighting.yaml
+++ b/clusters/lighting.yaml
@@ -122,8 +122,8 @@ types:
     unit: Seconds
     range: 0x0000,0xfffe
     multiplier: 10
-  Direction: &direction
-    name: Direction
+  MoveDirection: &moveDirection
+    name: Move Direction
     type: enum8
     values:
       "0x00": Shortest distance
@@ -798,7 +798,7 @@ clusters:
           dir: recv
           payloadattr:
             - *hue
-            - *direction
+            - *moveDirection
             - *transitionTime
         - id: "0x01"
           name: Move hue
@@ -872,7 +872,7 @@ clusters:
           required: true
           payloadattr:
             - *enhancedHue
-            - *direction
+            - *moveDirection
             - *transitionTime
         - id: "0x41"
           name: Enhanced move hue

--- a/zdo.yaml
+++ b/zdo.yaml
@@ -727,6 +727,7 @@ commands:
 
   - name: Active Endpoint Request
     id: "0x0005"
+    response: "0x8005"
     required: true
     description: |
       queries the remote device for a list of active endpoints. Should be unicast to the remote device directly,


### PR DESCRIPTION
Names of attributes and arguments might collide with generated functions.

This changes the name of `Direction` to `Move Direction` in the lighting domain, and adds a list of reserved names to the README